### PR TITLE
Bad frame rate at demo pages

### DIFF
--- a/scss/styleguide.scss
+++ b/scss/styleguide.scss
@@ -44,6 +44,7 @@ body {
 	margin-top: 3%;
 	margin-bottom: 3%;
 	@include border-radius(3px);
+	@include transform(translateZ(0));
 }
 .g-row + .g-row {
 	margin-top: 30px;


### PR DESCRIPTION
Playing with demo pages, I've noticed a bad frame rate(nearby 30fps) on scrolling, especially on [forms](http://tmwagency.github.io/kickoff/demos/forms.html#code-example-labels-above) and [grids](http://tmwagency.github.io/kickoff/demos/grids.html) pages. It is happening due to long paint time, so adding another composite layer for .g-container(by adding transform: translateZ(0) or [one of others](https://gist.github.com/sol0mka/8096451)) solves the issue. Sure it solves the result of the issue but not the reason. The reason for grids page is bunch of resized images so there is nothing else to do, I believe. The reason for forms page is not clear for me yet.

**upd:**
It is happening occasionally so probably couldn't be considered as an issue of the framework itself.
