### PR TITLE
Libssass 3.3.6 bugfix

### DIFF
--- a/assets/src/scss/components/_block-grids.scss
+++ b/assets/src/scss/components/_block-grids.scss
@@ -36,7 +36,7 @@ $block-grid-breakpoints: (
 
 	// default doesn't need a mutator
 	@if($mutator and not ($mutator == default)) {
-		$suffix: '--' + #{$mutator};
+		$suffix: '--' + $mutator;
 	}
 
 	@for $i from 1 to $grid-column-count + 1 {


### PR DESCRIPTION
Fix invalid code when compiling with latest libsass 3.3.6 

was getting.
```.l-blockGrid--2"--" + narrow .l-blockGrid-item { ..}```
Instead of
```.l-blockGrid--2--narrow .l-blockGrid-item {..}```
