### PR TITLE
IE11 Print fix - remove first-line attribute from print stylesheet

### DIFF
--- a/assets/src/scss/views/_print.scss
+++ b/assets/src/scss/views/_print.scss
@@ -8,8 +8,7 @@
 	*,
 	*:before,
 	*:after,
-	*:first-letter,
-	*:first-line {
+	*:first-letter {
 		background: transparent !important;
 		color: #000 !important; /* Black prints faster: http://www.sanbeiji.com/archives/953 */
 		box-shadow: none !important;


### PR DESCRIPTION
Removing this line of code, will avoid IE11 crashing on print preview & allow it to print.