### PR TITLE
Removed ceil because it caused buggy output. 

### DIFF
--- a/assets/src/scss/functions/_modular-scale.scss
+++ b/assets/src/scss/functions/_modular-scale.scss
@@ -63,5 +63,5 @@ $double-octave    : 4;
     }
   }
 
-  @return ceil($value);
+  @return $value;
 }


### PR DESCRIPTION
With ceil I get :bug:
``` scss
h2, .h2, .beta {
    font-size: 2.4166666667rem;
}
```
Without ceil I get :100:
``` scss
h2, .h2, .beta {
    font-size: 2.368593037rem;
}
```

Expected output should be 2.369 according to http://www.modularscale.com/?12&px&1.333&sass&text so I think this rounding should be removed.