### PR TITLE
fix(css.js): implement renaming dist css file

### DIFF
--- a/.kickoff/tasks/css.js
+++ b/.kickoff/tasks/css.js
@@ -10,6 +10,7 @@ const gutil = require('gulp-util');
 const banner = require('gulp-banner');
 const filesizegzip = require('filesizegzip');
 const tap = require('gulp-tap');
+const rename = require('gulp-rename');
 
 // PostCSS plugins
 const autoprefixer = require('autoprefixer');
@@ -56,6 +57,11 @@ gulp.task('css', () => {
 		// Write sourcemaps
 		.pipe(
 			config.isRelease ? gutil.noop() : sourcemaps.write()
+		)
+
+		// Rename dist file based on config
+		.pipe(
+			rename(config.css.distFile + '.css')
 		)
 
 		// Output file-size

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "gulp-banner": "0.1.3",
     "gulp-imagemin": "3.1.1",
     "gulp-postcss": "6.3.0",
+    "gulp-rename": "1.2.2",
     "gulp-sass": "3.1.0",
     "gulp-sourcemaps": "^2.4.1",
     "gulp-stylelint": "3.9.0",


### PR DESCRIPTION
Now, if you set the config.css.distFile option, the builded css file respect the setting.

It close the issue 157